### PR TITLE
Update r2proto.c Case NORTEL-CANTV Venezuela

### DIFF
--- a/src/r2proto.c
+++ b/src/r2proto.c
@@ -309,7 +309,7 @@ static openr2_variant_entry_t r2variants[] =
 	{
 		/* .id */ OR2_VAR_VENEZUELA,
 		/* .name */ "VE",
-		/* .country */ "Venezuela",
+		/* .country */ "Venezuela, incluye caso NORTEL-CANTV",
 		/* .config */ r2config_venezuela
 	}
 };
@@ -1255,8 +1255,12 @@ handlecas:
 	case OR2_SEIZE_TXD:
 	case OR2_SEIZE_TXD_CLEAR_FWD_PENDING:
 		/* if we transmitted a seize we expect the seize ACK */
-		if (cas == R2(r2chan, SEIZE_ACK)) {
-			CAS_LOG_RX(SEIZE_ACK);
+		/* if a case Nortel Cantv we also expect a FORCED RELEASE as a seize ACK */
+                if (cas == R2(r2chan, SEIZE_ACK) || cas == R2(r2chan,FORCED_RELEASE)) {
+                        CAS_LOG_RX(SEIZE_ACK);
+                        if (cas == R2(r2chan,FORCED_RELEASE)) {
+                                openr2_log(r2chan, OR2_LOG_DEBUG, "Forced Release as Seize ACK Case NORTEL-Cantv!\n");
+                        }
 			openr2_chan_cancel_timer(r2chan, &r2chan->timer_ids.r2_seize);
 			if (r2chan->r2_state == OR2_SEIZE_TXD_CLEAR_FWD_PENDING) {
 				openr2_log(r2chan, OR2_CHANNEL_LOG, 

--- a/src/r2proto.c
+++ b/src/r2proto.c
@@ -1109,7 +1109,7 @@ static int check_backward_disconnection(openr2_chan_t *r2chan, int cas,
 	   to have it here for other variants as well just in case. If we ever find a reason to
 	   just accept this signal for Brazil, we need just to check the variant here 
 	   as well, or use some sort of per-variant flag to accept it */
-	if (cas == R2(r2chan, FORCED_RELEASE)) {
+	if (cas == R2(r2chan, FORCED_RELEASE) && r2chan->r2context->variant != OR2_VAR_VENEZUELA ) {
 		CAS_LOG_RX(FORCED_RELEASE);
 		*state = OR2_FORCED_RELEASE_RXD;
 		*cause = OR2_CAUSE_FORCED_RELEASE;


### PR DESCRIPTION
Receive after TX Seize  a Seize_ACK (0x0 instead of a 0xC) :

Recientemente, me a tocado un caso acá en Venezuela, para incorporar varios enlaces salientes con señalización DTMF-R2, en los cuales la central de CANTV no sigue el estándar en los bits CAS para el SEIZE_ACK, que en este caso responde con 0x0 (0001) en lugar de 0xC (1101).  Estos enlaces actualmente están trabajando bien con una central NORTEL Meridian, que si tiene ese ajuste en su tabla de parámetros, pero nuestro interés es ir migrando los servicios a una central basada en asterisk18.24.3/openr2-1.3.3.

[14:38:21:606] [Thread: 140077508204288] [Chan 157] - Call started at Wed Nov 27 14:38:21 2024 on chan 157 [openr2 version 1.3.3, revision (release)]
[14:38:21:606] [Thread: 140077508204288] [Chan 157] - Outgoing call proceeding: ANI=7007, DNIS=04141111330, Category=National Subscriber
[14:38:21:606] [Thread: 140077508204288] [Chan 157] - CAS Tx >> [SEIZE] 0x00
[14:38:21:606] [Thread: 140077508204288] [Chan 157] - CAS Raw Tx >> 0x01
[14:38:21:606] [Thread: 140077508204288] [Chan 157] - scheduled timer id 2 (r2_seize)
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - Bits changed from 0x08 to 0x00
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - CAS Rx << [FORCED RELEASE] 0x00
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - Disconnection before seize ack detected![14:38:21:734] [Thread: 140077508204288] [Chan 157] - Far end disconnected. Reason: Forced Release
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - scheduled timer id 3 (dtmf_r2_set_call_down)
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - Attempting to cancel timer timer 0
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - Cannot cancel timer 0
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - CAS Tx >> [CLEAR FORWARD] 0x08
[14:38:21:734] [Thread: 140077508204288] [Chan 157] - CAS Raw Tx >> 0x09
[14:38:21:846] [Thread: 140079335577344] [Chan 157] - Attempting to cancel timer timer 3
[14:38:21:846] [Thread: 140079335577344] [Chan 157] - timer id 3 found, cancelling it now
[14:38:21:846] [Thread: 140079335577344] [Chan 157] - calling timer 3 (dtmf_r2_set_call_down) callback
[14:38:21:846] [Thread: 140079335577344] [Chan 157] - Call ended
[14:38:21:846] [Thread: 140079335577344] [Chan 157] - Attempting to cancel timer timer 0
[14:38:21:846] [Thread: 140079335577344] [Chan 157] - Cannot cancel timer 0

en un intento inicial, se incorporo la siguiente condición (este comitt) para considerar el caso, pero no se recibe el cambio ANSWER (0x4), al responder la llamada. seguimos analizando la llamada que si se logra en la central NORTEL.


Ahora la llamada ocurre asi:

[11:00:11:982] [Thread: 139974327080704] [Chan 156] - Call started at Thu Dec  5 11:00:11 2024 on chan 156 [openr2 version 1.3.4, revision (release)]
[11:00:11:982] [Thread: 139974327080704] [Chan 156] - Outgoing call proceeding: ANI=7007, DNIS=04161992083, Category=National Subscriber
[11:00:11:982] [Thread: 139974327080704] [Chan 156] - CAS Tx >> [SEIZE] 0x00
[11:00:11:982] [Thread: 139974327080704] [Chan 156] - CAS Raw Tx >> 0x01
[11:00:11:982] [Thread: 139974327080704] [Chan 156] - scheduled timer id 2 (r2_seize)
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - Bits changed from 0x08 to 0x00
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - CAS Rx << [SEIZE ACK] 0x00
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - Forced Release as Seize ACK Case Movilnet-Cantv!
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - Attempting to cancel timer timer 2
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - timer id 2 found, cancelling it now
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - DTMF/R2 call acknowledge!
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - scheduled timer id 3 (start_dialing_dtmf)
[11:00:12:103] [Thread: 139974327080704] [Chan 156] - scheduled timer id 4 (r2_answer)
[11:00:12:622] [Thread: 139974327080704] [Chan 156] - Attempting to cancel timer timer 3
[11:00:12:622] [Thread: 139974327080704] [Chan 156] - timer id 3 found, cancelling it now
[11:00:12:622] [Thread: 139974327080704] [Chan 156] - calling timer 3 (start_dialing_dtmf) callback
[11:00:12:622] [Thread: 139974327080704] [Chan 156] - Dialing 04161992083 with DTMF/R2 (tone on = 50, tone off = 100)
[11:00:14:222] [Thread: 139974327080704] [Chan 156] - Done with DTMF generation
[11:00:14:222] [Thread: 139974327080704] [Chan 156] - Attempting to cancel timer timer 0
[11:00:14:222] [Thread: 139974327080704] [Chan 156] - Cannot cancel timer 0
[11:00:14:222] [Thread: 139974327080704] [Chan 156] - DTMF R2 call is done generating DTMF, forcing accept signal
[11:00:59:157] [Thread: 139974327080704] [Chan 156] - scheduled timer id 5 (dtmf_r2_set_call_down)
[11:00:59:157] [Thread: 139974327080704] [Chan 156] - Attempting to cancel timer timer 0
[11:00:59:157] [Thread: 139974327080704] [Chan 156] - Cannot cancel timer 0
[11:00:59:157] [Thread: 139974327080704] [Chan 156] - CAS Tx >> [CLEAR FORWARD] 0x08
[11:00:59:157] [Thread: 139974327080704] [Chan 156] - CAS Raw Tx >> 0x09
[11:00:59:262] [Thread: 139976154019584] [Chan 156] - Attempting to cancel timer timer 5
[11:00:59:262] [Thread: 139976154019584] [Chan 156] - timer id 5 found, cancelling it now
[11:00:59:262] [Thread: 139976154019584] [Chan 156] - calling timer 5 (dtmf_r2_set_call_down) callback
[11:00:59:262] [Thread: 139976154019584] [Chan 156] - Call ended
[11:00:59:262] [Thread: 139976154019584] [Chan 156] - Attempting to cancel timer timer 0
[11:00:59:262] [Thread: 139976154019584] [Chan 156] - Cannot cancel timer 0